### PR TITLE
P3dr/8.0.1

### DIFF
--- a/llvm/include/llvm/Demangle/MicrosoftDemangle.h
+++ b/llvm/include/llvm/Demangle/MicrosoftDemangle.h
@@ -16,6 +16,7 @@
 #include "llvm/Demangle/Utility.h"
 
 #include <utility>
+#include <cstdint>
 
 namespace llvm {
 namespace ms_demangle {

--- a/llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h
+++ b/llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h
@@ -3,7 +3,10 @@
 
 #include "llvm/Demangle/Compiler.h"
 #include "llvm/Demangle/StringView.h"
+
 #include <array>
+#include <cstdint>
+#include <string>
 
 class OutputStream;
 

--- a/llvm/utils/benchmark/src/benchmark_register.h
+++ b/llvm/utils/benchmark/src/benchmark_register.h
@@ -2,6 +2,7 @@
 #define BENCHMARK_REGISTER_H
 
 #include <vector>
+#include <limits>
 
 #include "check.h"
 


### PR DESCRIPTION
Add missing includes. This fixes compilation on Ubuntu with clang-14.